### PR TITLE
fix: add warn log for oversized image rejection

### DIFF
--- a/crates/coop-core/src/images.rs
+++ b/crates/coop-core/src/images.rs
@@ -62,6 +62,12 @@ pub fn load_image(path: &str) -> Result<(String, String)> {
 
     let meta = std::fs::metadata(p)?;
     if meta.len() > MAX_IMAGE_SIZE {
+        tracing::warn!(
+            path = %path,
+            size_bytes = meta.len(),
+            max_bytes = MAX_IMAGE_SIZE,
+            "image exceeds 5 MB API limit, skipping injection"
+        );
         bail!(
             "image file exceeds 5 MB limit ({} bytes): {path}",
             meta.len()


### PR DESCRIPTION
Adds a `tracing::warn!` when `load_image()` rejects a file over 5MB. Previously this silently bailed with an error that callers swallowed at trace level, making it hard to diagnose in logs.

Note: this addresses logging only. The 400 error Matt hit (5,477,196 bytes) may have come from an image already inline in a tool result, bypassing `load_image()` entirely. That code path may need a separate size guard in the provider serialization layer.